### PR TITLE
Add simple schema registry

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/corekind"
 	_go "github.com/grafana/grok/gen/go"
 	"github.com/grafana/grok/gen/jsonschema"
+	"github.com/grafana/grok/gen/registry"
 	"github.com/grafana/grok/internal/jen"
 	"github.com/grafana/thema"
 )
@@ -63,6 +64,7 @@ func lineUpJennies() jen.TargetJennies {
 	tgtmap := map[string]jen.TargetJennies{
 		"go":         _go.JenniesForGo(),
 		"jsonschema": jsonschema.JenniesForJsonSchema(),
+		"registry":   registry.JenniesForRegistry(),
 	}
 
 	for path, tj := range tgtmap {

--- a/gen/registry/registry.go
+++ b/gen/registry/registry.go
@@ -1,0 +1,105 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/grafana/pkg/codegen"
+	"github.com/grafana/grafana/pkg/kindsys"
+	"github.com/grafana/grok/internal/jen"
+)
+
+func JenniesForRegistry() jen.TargetJennies {
+	tgt := jen.NewTargetJennies()
+
+	tgt.Core.Append(&CoreRegistryJenny{})
+	tgt.Composable.Append(&ComposableRegistryJenny{})
+
+	return tgt
+}
+
+type CoreRegistryJenny struct{}
+
+func (j *CoreRegistryJenny) JennyName() string {
+	return "CoreRegistryJenny"
+}
+
+func (j *CoreRegistryJenny) Generate(decls ...*codegen.DeclForGen) (*codejen.File, error) {
+
+	type versionMapping struct {
+		Kind   string `json:"kind"`
+		Schema string `json:"version"`
+	}
+
+	versions := []versionMapping{}
+
+	grafanaVersion := os.Getenv("GRAFANA_VERSION")
+	if grafanaVersion == "" {
+		return nil, nil
+	}
+	for _, decl := range decls {
+		var schemaVersion string
+		if decl.Properties.Common().Maturity.Less(kindsys.MaturityStable) {
+			schemaVersion = "x"
+		} else {
+			schemaVersion = decl.ForLatestSchema().Schema.Version().String()
+		}
+		versions = append(versions, versionMapping{
+			Kind:   decl.Lineage().Name(),
+			Schema: schemaVersion,
+		})
+	}
+	str, err := json.MarshalIndent(versions, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	filename := fmt.Sprintf("%s/registry-core.json", grafanaVersion)
+	return codejen.NewFile(filename, []byte(str), j), nil
+}
+
+type ComposableRegistryJenny struct{}
+
+func (j *ComposableRegistryJenny) JennyName() string {
+	return "JsonSchemaIndexJenny"
+}
+
+func (j *ComposableRegistryJenny) Generate(comps ...*jen.ComposableForGen) (*codejen.File, error) {
+
+	type versionMapping struct {
+		Kind            string `json:"kind"`
+		SchemaInterface string `json:"schemaInterface"`
+		Schema          string `json:"version"`
+	}
+
+	versions := []versionMapping{}
+
+	grafanaVersion := os.Getenv("GRAFANA_VERSION")
+	if grafanaVersion == "" {
+		return nil, nil
+	}
+
+	for _, comp := range comps {
+		var schemaVersion string
+		// Hardwiring maturity, as composables/plugins don't fully support kind system yet
+		// see also internal/jen/jenny_eachmajorcomposable.go:
+		maturity := kindsys.MaturityExperimental
+		if maturity.Less(kindsys.MaturityStable) {
+			schemaVersion = "x"
+		} else {
+			schemaVersion = comp.Lineage.Latest().Version().String()
+		}
+		versions = append(versions, versionMapping{
+			Kind:            comp.Lineage.Name(),
+			SchemaInterface: comp.Slot.Name(),
+			Schema:          schemaVersion,
+		})
+	}
+	str, err := json.MarshalIndent(versions, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	filename := fmt.Sprintf("%s/registry-composable.json", grafanaVersion)
+	return codejen.NewFile(filename, []byte(str), j), nil
+}

--- a/registry/v9.3.2/registry-composable.json
+++ b/registry/v9.3.2/registry-composable.json
@@ -1,0 +1,52 @@
+[
+  {
+    "kind": "annolist",
+    "schemaInterface": "Panel",
+    "version": "x"
+  },
+  {
+    "kind": "barchart",
+    "schemaInterface": "Panel",
+    "version": "x"
+  },
+  {
+    "kind": "bargauge",
+    "schemaInterface": "Panel",
+    "version": "x"
+  },
+  {
+    "kind": "dashlist",
+    "schemaInterface": "Panel",
+    "version": "x"
+  },
+  {
+    "kind": "gauge",
+    "schemaInterface": "Panel",
+    "version": "x"
+  },
+  {
+    "kind": "histogram",
+    "schemaInterface": "Panel",
+    "version": "x"
+  },
+  {
+    "kind": "news",
+    "schemaInterface": "Panel",
+    "version": "x"
+  },
+  {
+    "kind": "piechart",
+    "schemaInterface": "Panel",
+    "version": "x"
+  },
+  {
+    "kind": "stat",
+    "schemaInterface": "Panel",
+    "version": "x"
+  },
+  {
+    "kind": "text",
+    "schemaInterface": "Panel",
+    "version": "x"
+  }
+]

--- a/registry/v9.3.2/registry-core.json
+++ b/registry/v9.3.2/registry-core.json
@@ -1,0 +1,14 @@
+[
+  {
+    "kind": "dashboard",
+    "version": "x"
+  },
+  {
+    "kind": "playlist",
+    "version": "x"
+  },
+  {
+    "kind": "team",
+    "version": "x"
+  }
+]


### PR DESCRIPTION
Grafana schemas have their own versioning system, independent of Grafana itself. This versioning system is
typically `$MAJOR.$MINOR`, with the addition of `x` which means "experimental".

When rendering libraries based upon these schema, end users will be concerned about Grafana versions. So
we need a mapping between. This PR is a first pass at solving that.

If Grok's `go generate` is called with a `GRAFANA_VERSION` envvar set, the new "registry jennies" will
kick in, rendering two files (core and composable) for that specific Grafana version. They basically say
"this version of Grafana uses these schema version for these kinds".

This mapping can then be used by downstream libraries (or Grok itself) to render code for various languages.

