### PR TITLE
Maturity: make minimum configurable

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -34,15 +34,17 @@ func main() {
 	var corek []kindsys.Kind
 	var compok []kindsys.Composable
 
+	maturity := kindsys.NewMaturity(os.Getenv("MINIMUM_MATURITY"))
+
 	for _, kind := range corekind.NewBase(nil).All() {
-		if kind.Maturity().Less(kindsys.MaturityExperimental) {
+		if kind.Maturity().Less(maturity) {
 			continue
 		}
 		corek = append(corek, kind)
 	}
 	for _, pp := range corelist.New(nil) {
 		for _, kind := range pp.ComposableKinds {
-			if kind.Maturity().Less(kindsys.MaturityExperimental) {
+			if kind.Maturity().Less(maturity) {
 				continue
 			}
 			compok = append(compok, kind)

--- a/gen/jsonnet/jsonnet.go
+++ b/gen/jsonnet/jsonnet.go
@@ -1,7 +1,6 @@
 package jsonnet
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,12 +16,10 @@ func JenniesForJsonnet() jen.TargetJennies {
 	if grafanaVersion == "" {
 		return tgt
 	}
-	log.Print("CORE")
 	tgt.Core.Append(
 		&JsonnetCoreImportsJenny{},
 		codegen.LatestMajorsOrXJenny(filepath.Join(grafanaVersion, "kinds", "core"), JsonnetSchemaJenny{}),
 	)
-	log.Print("COMP")
 	tgt.Composable.Append(
 		// oooonly need to inject the proper path interstitial to make this right
 		&JsonnetComposableImportsJenny{},


### PR DESCRIPTION
Grok currently imposes a minimum level of maturity of `experimental`. This
makes clear sense - anything less than experimental lacks sufficient thought
to be reliably usable.

However, in the very early phases of building downstream libraries, access to
a schema (however immature) is more valuable than a guarantee of minimum
maturity.

This PR allows the user invoking `go generate` to set a mimimum maturity,
potentially including the `merged` schemas. This could also be used to
only render schemas that are `stable` or `merged`.

It is fully intended that this feature will not be used once Grok goes GA,
and could well be removed.

This PR depends upon https://github.com/grafana/grafana/pull/63631.
