### PR TITLE
Remove GRAFANA_VERSION environment variable usage in jsonnet jenny

### DIFF
--- a/gen/jsonnet/jsonnet.go
+++ b/gen/jsonnet/jsonnet.go
@@ -17,7 +17,7 @@ func JenniesForJsonnet(targetGrafanaVersion string) jen.TargetJennies {
 	)
 	tgt.Composable.Append(
 		// oooonly need to inject the proper path interstitial to make this right
-		&JsonnetComposableImportsJenny{},
+		&JsonnetComposableImportsJenny{GrafanaVersion: targetGrafanaVersion},
 		jen.ComposableLatestMajorsOrXJenny(filepath.Join(targetGrafanaVersion, "kinds", "composable"), JsonnetSchemaJenny{}),
 	)
 

--- a/internal/jen/jenny_eachmajorcomposable.go
+++ b/internal/jen/jenny_eachmajorcomposable.go
@@ -34,7 +34,7 @@ func (j *clmox) JennyName() string {
 func (j *clmox) Generate(k kindsys.Composable) (codejen.Files, error) {
 	si, err := kindsys.FindSchemaInterface(k.Def().Properties.SchemaInterface)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	sfg := codegen.SchemaForGen{
 		Name:    k.Lineage().Name(),


### PR DESCRIPTION
A bit of house cleaning while exploring the code base: some jsonnet-related jennies were still relying on a `GRAFANA_VERSION` environment variable instead of an injected value.